### PR TITLE
Added missing nav menu registration for Foundation navigation

### DIFF
--- a/lib/components/foundation-menu/foundation-functions.php
+++ b/lib/components/foundation-menu/foundation-functions.php
@@ -14,6 +14,13 @@ remove_action( 'genesis_site_description', 'genesis_seo_site_description' );
  */
 // Remove Genesis Nav Support
 remove_theme_support( 'genesis-menus' );
+
+// Register Foundation Navigation
+add_action( 'init', 'register_foundation_menu' );
+function register_foundation_menu() {
+  register_nav_menu('primary-navigation',__( 'Primary Navigation' ));
+}
+
 /*********************
 ADD FOUNDATION FEATURES TO WORDPRESS
 *********************/


### PR DESCRIPTION
Not doing so seems to work with a simple setup but that's just because of WordPress' fallbacks to search for available menus if nothing is specified.

See also: [Incorrect usage of wp_nav_menu – Polylang](https://polylang.pro/incorrect-usage-of-wp_nav_menu/)
